### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
  
   def index
-    #@items = Item.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
- 
+
   def index
     @items = Item.order('created_at DESC')
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,10 +127,15 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
+    
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
+         
+
+            <%#div class="content_post" style="background-image: url(<%= tweet.image %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +146,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee_id %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,6 +158,7 @@
         </div>
         <% end %>
       </li>
+       <% end %>  
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -162,8 +162,6 @@
       <%# 商品がある場合は表示されないようにしましょう %>
       
       <% if @items.length == 0 %>
-      <% end %>
-      
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -185,6 +183,7 @@
       <%# /商品がない場合のダミー %>
     </ul>
   </div>
+  <% end %>
   <%# /商品一覧 %>
 </div>
 <%= link_to(new_item_path, method: :get, class: 'purchase-btn') do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -160,6 +160,10 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      
+      <% if @items.length == 0 %>
+      <% end %>
+      
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,9 +133,6 @@
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
-         
-
-            <%#div class="content_post" style="background-image: url(<%= tweet.image %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -68,31 +68,31 @@ RSpec.describe Item, type: :model do
         it 'カテゴリーの情報がidが1だと投稿できない' do
           @item.category_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Category must be other than 1")
+          expect(@item.errors.full_messages).to include('Category must be other than 1')
         end
 
         it '商品の状態についての情報がidが1だと投稿できない' do
           @item.status_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Status must be other than 1")
+          expect(@item.errors.full_messages).to include('Status must be other than 1')
         end
 
         it '配送料の負担についての情報がidが1だと投稿できない' do
           @item.delivery_fee_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Delivery fee must be other than 1")
+          expect(@item.errors.full_messages).to include('Delivery fee must be other than 1')
         end
 
         it '発送元の地域についての情報がidが1だと投稿できない' do
           @item.area_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Area must be other than 1")
+          expect(@item.errors.full_messages).to include('Area must be other than 1')
         end
 
         it '発送までの日数についての情報がidが1だと投稿できない' do
           @item.days_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Days must be other than 1")
+          expect(@item.errors.full_messages).to include('Days must be other than 1')
         end
 
         # 価格のテスト ▼


### PR DESCRIPTION
#What（どのような実装をしているのか）
出品された商品はトップページに一覧で表示させる

#Why（なぜこの実装が必要なのか）
以下を実装させるため
出品した商品の一覧表示ができていること
上から、出品された日時が新しい順に表示されること
「画像/価格/商品名」の3つの情報について表示できていること
ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること

#ログイン
https://gyazo.com/6b855108622eed7a81beedd48fdbfa69

＃ログアウト
https://gyazo.com/2d5dd563484076c4c3ed0211ad257917

#新規投稿
https://gyazo.com/182b9bac76bafa4c55eb474343105bf5