### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,8 +14,12 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-      render :new
+      render :show
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,7 +14,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-      render :show
+      render :new
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,7 +4,7 @@ class Item < ApplicationRecord
   belongs_to :status
   belongs_to :delivery_fee
   belongs_to :area
-  belongs_to :day
+  belongs_to :days
 
   with_options presence: true do
     validates :image

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
       <% @items.each do |item| %>
       <li class='list'>
     
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id), method: :get do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
@@ -146,7 +146,7 @@
             <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.delivery_fee_id %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -104,7 +104,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%= ¥{@item.price} %>
+        <%= "¥#{@item.price}" %>
       </span>
       <span class="item-postage">
         <%= @item.delivery_fee.name %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -19,20 +19,22 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.delivery_fee.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>%
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+     <% else %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
@@ -43,27 +45,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname  %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= ¥{@item.price} %>
       </span>
       <span class="item-postage">
         <%= @item.delivery_fee.name %>


### PR DESCRIPTION
#What（どのような実装をしているのか）
商品詳細表示ページにて、商品の詳細情報を表示させる

#Why（なぜこの実装が必要なのか）
以下のことを実装させるため

ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
商品出品時に登録した情報が見られるようになっていること

#商品出品時に登録した情報が見られる
https://gyazo.com/2e32752524041bad76200a2b3769f2d2

#ログイン状態の出品者のみ、「編集・削除ボタン」が表示される「購入画面に進むボタン」が表示されない
https://gyazo.com/d6ce33c9a50f1ba3a106a8825d123ca6

#ログイン状態の出品者以外のユーザーのみ、「編集・削除ボタン」が表示されず「購入画面に進むボタン」が表示される
https://gyazo.com/3f057494c540c5aff70eae6ac34804fc

#ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
#ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://gyazo.com/ff38e22401d8538858ccb5dc73314c4f

#商品詳細 実価格
https://gyazo.com/59f72d80aa569b8f779eeb2100fe749c